### PR TITLE
Make images smaller

### DIFF
--- a/chisel/Dockerfile
+++ b/chisel/Dockerfile
@@ -10,11 +10,13 @@ MAINTAINER Henry Cook (hcook) <henry@sifive.com>
 
 # Populate $HOME/.ivy2/cache
 WORKDIR $RISCV
-RUN git clone https://github.com/ucb-bar/rocket-chip.git
-WORKDIR $RISCV/rocket-chip
-RUN git submodule update --init
-RUN cd firrtl; java -Xmx2G -Xss8M -jar $RISCV/rocket-chip/sbt-launch.jar "publish-local"
-RUN cd chisel3; java -Xmx2G -Xss8M -jar $RISCV/rocket-chip/sbt-launch.jar "publish-local"
-WORKDIR $RISCV
-RUN rm -rf rocket-chip
+RUN git clone https://github.com/ucb-bar/rocket-chip.git && \
+  cd rocket-chip && \
+    git submodule update --init && \
+    cd firrtl && \
+      java -Xmx2G -Xss8M -jar $RISCV/rocket-chip/sbt-launch.jar "publish-local" && \
+    cd ../chisel3 && \
+      java -Xmx2G -Xss8M -jar $RISCV/rocket-chip/sbt-launch.jar "publish-local" && \
+  cd ../.. && \
+  rm -rf rocket-chip
 WORKDIR $RISCV/test

--- a/riscv-tools/Dockerfile
+++ b/riscv-tools/Dockerfile
@@ -24,10 +24,9 @@ ENV PATH $RISCV/bin:$PATH
 # so make sure we get those too.
 WORKDIR $RISCV
 RUN git clone https://github.com/riscv/riscv-tools.git && \
-  cd riscv-tools && git submodule update --init --recursive
-
-# Now build the toolchain for RISCV. Set -j 1 to avoid issues on VMs.
-WORKDIR $RISCV/riscv-tools
-RUN sed -i 's/JOBS=16/JOBS=1/' build.common && \
-  ./build.sh
-RUN rm -rf *
+  cd riscv-tools && \
+    git submodule update --init --recursive && \
+    sed -i 's/JOBS=16/JOBS=1/' build.common && \
+    ./build.sh && \
+  cd .. && \
+    rm -rf riscv-tools


### PR DESCRIPTION
I haven't tested this, so I'd appreciate if you could double check my work and especially double check that all the `cd` commands are correct.

### Explanation
Aside from the issue with `rm -rf *` missing the `.git` directory that I mentioned to you offline, a second issue with the way these Dockerfiles are written is that they create intermediate image layers that still contain a snapshot of the filesystem prior to the `rm` commands, which means that you aren't actually making the images smaller.

A simplified explanation of how Docker works is that it creates a filesystem snapshot for every Docker command in the Dockerfile (i.e. each `RUN`, `WORKDIR`, `ENV`, `ADD` will create a new snapshot). These snapshots are differential, so they only record new files that are added. However, this means that if you have two separate RUN commands where the first generates a lot of data and the second removes it, you still end up creating a snapshot that saves all the data. Since you must pull all parent layers, this means that even if the final result of applying all the layers is small, you may still have very large intermediate layers.

Just to demonstrate how big of a difference this will make, here's how large each layer currently is:

```sh
$ docker images hcook/docker-riscv:chisel
REPOSITORY           TAG                 IMAGE ID            CREATED             SIZE
hcook/docker-riscv   chisel              28406377ba93        13 days ago         7.671 GB

$ docker history hcook/docker-riscv:chisel
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
28406377ba93        13 days ago         /bin/sh -c #(nop)  WORKDIR /opt/riscv/test      0 B                 
<missing>           13 days ago         /bin/sh -c rm -rf rocket-chip                   0 B                 
<missing>           13 days ago         /bin/sh -c #(nop)  WORKDIR /opt/riscv           0 B                 
<missing>           13 days ago         /bin/sh -c cd chisel3; java -Xmx2G -Xss8M -ja   95.45 MB            
<missing>           13 days ago         /bin/sh -c cd firrtl; java -Xmx2G -Xss8M -jar   160.7 MB            
<missing>           13 days ago         /bin/sh -c git submodule update --init          59.64 MB            
<missing>           13 days ago         /bin/sh -c #(nop)  WORKDIR /opt/riscv/rocket-   0 B                 
<missing>           13 days ago         /bin/sh -c git clone https://github.com/ucb-b   13.84 MB            
<missing>           13 days ago         /bin/sh -c #(nop)  WORKDIR /opt/riscv           0 B                 
<missing>           13 days ago         /bin/sh -c #(nop)  MAINTAINER Henry Cook (hco   0 B                 
<missing>           13 days ago         /bin/sh -c #(nop)  WORKDIR /opt/riscv/test      0 B                 
<missing>           13 days ago         /bin/sh -c #(nop)  ENV TARGET_VERILATOR=/usr/   0 B                 
<missing>           13 days ago         /bin/sh -c #(nop)  ENV INSTALLED_VERILATOR=/u   0 B                 
<missing>           13 days ago         /bin/sh -c make install                         44.91 MB            
<missing>           13 days ago         /bin/sh -c make                                 217.8 MB            
<missing>           13 days ago         /bin/sh -c ./configure                          91.66 kB            
<missing>           13 days ago         /bin/sh -c autoconf                             361.8 kB            
<missing>           13 days ago         /bin/sh -c git checkout verilator_3_884         3.019 MB            
<missing>           13 days ago         /bin/sh -c #(nop)  WORKDIR /opt/riscv/test/ve   0 B                 
<missing>           13 days ago         /bin/sh -c git clone http://git.veripool.org/   14.23 MB            
<missing>           13 days ago         /bin/sh -c #(nop)  WORKDIR /opt/riscv/test      0 B                 
<missing>           13 days ago         /bin/sh -c #(nop)  MAINTAINER Henry Cook (hco   0 B                 
<missing>           6 weeks ago         /bin/sh -c rm -rf *                             0 B                 
<missing>           6 weeks ago         /bin/sh -c sed -i 's/JOBS=16/JOBS=1/' build.c   3.392 GB            
<missing>           6 weeks ago         /bin/sh -c #(nop)  WORKDIR /opt/riscv/riscv-t   0 B                 
<missing>           6 weeks ago         /bin/sh -c git clone https://github.com/riscv   2.853 GB            
<missing>           6 weeks ago         /bin/sh -c #(nop)  WORKDIR /opt/riscv           0 B                 
<missing>           6 weeks ago         /bin/sh -c #(nop)  ENV PATH=/opt/riscv/bin:/u   0 B                 
<missing>           6 weeks ago         /bin/sh -c touch $RISCV/install.stamp           0 B                 
<missing>           6 weeks ago         /bin/sh -c mkdir -p $RISCV                      0 B                 
<missing>           6 weeks ago         /bin/sh -c #(nop)  ENV RISCV=/opt/riscv         0 B                 
<missing>           6 weeks ago         /bin/sh -c #(nop)  MAINTAINER Henry Cook (hco   0 B                 
<missing>           6 weeks ago         /bin/sh -c apt-get update && apt-get install    173.6 MB            
<missing>           6 weeks ago         /bin/sh -c #(nop)  MAINTAINER Henry Cook (hco   0 B                 
<missing>           10 weeks ago        /bin/sh -c /var/lib/dpkg/info/ca-certificates   418.2 kB            
<missing>           10 weeks ago        /bin/sh -c set -x  && apt-get update  && apt-   351.5 MB            
<missing>           10 weeks ago        /bin/sh -c #(nop)  ENV CA_CERTIFICATES_JAVA_V   0 B                 
<missing>           10 weeks ago        /bin/sh -c #(nop)  ENV JAVA_DEBIAN_VERSION=8u   0 B                 
<missing>           10 weeks ago        /bin/sh -c #(nop)  ENV JAVA_VERSION=8u111       0 B                 
<missing>           10 weeks ago        /bin/sh -c #(nop)  ENV JAVA_HOME=/usr/lib/jvm   0 B                 
<missing>           10 weeks ago        /bin/sh -c {   echo '#!/bin/sh';   echo 'set    87 B                
<missing>           10 weeks ago        /bin/sh -c #(nop)  ENV LANG=C.UTF-8             0 B                 
<missing>           10 weeks ago        /bin/sh -c echo 'deb http://deb.debian.org/de   55 B                
<missing>           10 weeks ago        /bin/sh -c apt-get update && apt-get install    1.287 MB            
<missing>           10 weeks ago        /bin/sh -c apt-get update && apt-get install    122.6 MB            
<missing>           10 weeks ago        /bin/sh -c apt-get update && apt-get install    44.3 MB             
<missing>           10 weeks ago        /bin/sh -c #(nop)  CMD ["/bin/bash"]            0 B                 
<missing>           10 weeks ago        /bin/sh -c #(nop) ADD file:41ea5187c50116884c   123 MB
```

Of the entire 7.6 GB image, there is a 2.9 GB layer right in the middle that corresponds to the cloning of `riscv-tools`.

### What I changed

I've combined several sequences of `RUN` and `WORKDIR` commands into a single `RUN` that does an `rm` at the end, which should at least allow us to shave about 3GB from the total image size.

Also, one more Docker tip: The `WORKDIR` command is being abused in the Dockerfiles in this repo. It's not meant to replace `cd` in a `RUN` command; it's really meant to set the default working directory that `docker run` uses, so you really only should have at most one WORKDIR in a Dockerfile.